### PR TITLE
Refactor: remove react as a peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,9 +61,7 @@
     "vite": "^2.4.4"
   },
   "peerDependencies": {
-    "@11ty/eleventy": "1.0.0-canary.41",
-    "react": "^17.0.2",
-    "react-dom": "^17.0.2"
+    "@11ty/eleventy": "1.0.0-canary.41"
   },
   "devDependencies": {
     "@babel/cli": "^7.14.8",

--- a/src/plugin/reactPlugin/toRendererHtml.js
+++ b/src/plugin/reactPlugin/toRendererHtml.js
@@ -1,6 +1,3 @@
-const { renderToString } = require('react-dom/server')
-const parseHtmlToReact = require('html-react-parser')
-const React = require('react')
 
 module.exports = function toRendererHtml({
   componentPath = '',
@@ -10,8 +7,13 @@ module.exports = function toRendererHtml({
   isPage = false,
   innerHTML = '',
 }) {
+  // only import these dependencies when triggered
+  // this prevents "cannot find module react*"
+  // when running slinkity without react and react-dom installed
+  const parseHtmlToReact = require('html-react-parser')
+  const { renderToString } = require('react-dom/server')
   const elementAsHTMLString = renderToString(
-    React.createElement(Component, props, parseHtmlToReact(innerHTML || ''))
+    require('react').createElement(Component, props, parseHtmlToReact(innerHTML || ''))
   )
   if (render === 'static') {
     return elementAsHTMLString


### PR DESCRIPTION
Resolves [an issue raised](https://github.com/Holben888/slinkity-home/issues/6) on the (now archived) docs repo.

Inlines all `react` and `react`-related imports, which happen to all be inside `toRendererHtml`. Hooray for abstraction!